### PR TITLE
Refactor kart game to terminal version

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,18 @@ Use the arrow keys to move the snake and press `q` to quit.
 The game renders each column twice so horizontal and vertical movement
 appear at the same speed.
 
+## Kart Game Example
+`src/kart_game.py` provides a tiny terminal kart demo drawn with ANSI colors.
+Trees line the sides of the track and rocks appear as obstacles. Control the
+kart with `W`/`S` for acceleration and brake and `A`/`D` for turning.
+
+### Run the game
+```bash
+python src/kart_game.py
+```
+No external dependencies are required. In non-interactive environments run
+`python src/kart_game.py --test` to execute a short automated session.
+
 
 ### GitHub workflow overview
 1. **Clone the repository**: `git clone <repository-url>`

--- a/src/kart_game.py
+++ b/src/kart_game.py
@@ -1,0 +1,102 @@
+"""Terminal kart racing demo using only the Python standard library.
+
+Controls:
+    W - Accelerate
+    S - Brake
+    A - Move left
+    D - Move right
+
+Run the game with `python src/kart_game.py`. Use `--test` to run a short
+non-interactive session for automated checks.
+"""
+
+import argparse
+import random
+import time
+
+
+WIDTH = 20  # track width (columns)
+HEIGHT = 10  # visible rows
+
+# ANSI color helpers
+RESET = "\033[0m"
+GREEN = "\033[32m"
+RED = "\033[31m"
+GREY_BG = "\033[47m"
+
+
+def clear() -> None:
+    """Clear the terminal screen."""
+    print("\033[H\033[J", end="")
+
+
+def render(kart_x: int, obstacles: list[tuple[int, int]], clear_screen: bool = True) -> None:
+    """Render the track, kart, trees, and rocks."""
+    if clear_screen:
+        clear()
+    for y in range(HEIGHT):
+        line = []
+        for x in range(WIDTH):
+            if x == 0 or x == WIDTH - 1:
+                line.append(GREEN + "T" + RESET)  # trees at the sides
+            else:
+                cell = GREY_BG + " " + RESET  # road
+                for ox, oy in obstacles:
+                    if (ox, oy) == (x, y):
+                        cell = RED + "O" + RESET  # rock obstacle
+                if y == HEIGHT - 1 and x == kart_x:
+                    cell = RED + "K" + RESET  # kart
+                line.append(cell)
+        print("".join(line))
+    print("Use WASD then Enter to move, Q to quit")
+
+
+def game(test_mode: bool = False) -> None:
+    kart_x = WIDTH // 2
+    speed = 0
+    obstacles: list[tuple[int, int]] = []
+    frame = 0
+    commands = iter("wdwdss") if test_mode else None
+
+    while True:
+        render(kart_x, obstacles, clear_screen=not test_mode)
+
+        if (kart_x, HEIGHT - 1) in obstacles:
+            print("Crashed!")
+            break
+
+        if test_mode:
+            try:
+                cmd = next(commands)
+            except StopIteration:
+                break
+        else:
+            cmd = input().lower().strip()[:1]
+
+        if cmd == "q":
+            break
+        if cmd == "w":
+            speed = 1
+        elif cmd == "s":
+            speed = 0
+        elif cmd == "a":
+            kart_x = max(1, kart_x - 1)
+        elif cmd == "d":
+            kart_x = min(WIDTH - 2, kart_x + 1)
+
+        # Move obstacles downward based on speed
+        obstacles = [(x, y + speed) for x, y in obstacles if y + speed < HEIGHT]
+
+        # Add a new obstacle every few frames
+        if frame % 3 == 0:
+            obstacles.append((random.randint(1, WIDTH - 2), 0))
+        frame += 1
+        time.sleep(0.2)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Simple terminal kart game")
+    parser.add_argument("--test", action="store_true", help="Run short automated test")
+    args = parser.parse_args()
+    game(test_mode=args.test)
+


### PR DESCRIPTION
## Summary
- replace Pygame kart demo with standard-library terminal version
- document terminal kart game and remove Pygame dependency
- drop pygame requirement for easier setup

## Testing
- `pip install -r requirements.txt`
- `python src/kart_game.py --test`


------
https://chatgpt.com/codex/tasks/task_e_68bfe9a51ff48331a21e9e4369ab0396